### PR TITLE
Use cryptographically strong random numbers for nonce

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,10 +100,9 @@ class UsernameToken {
   }
 
   private _newNonce(): string {
-    return new Array(10)
-      .fill(0)
-      .map(() => Math.floor(Math.random() * 256).toString(16))
-      .join('');
+    const buf = Buffer.alloc(10);
+    crypto.randomFillSync(buf);
+    return buf.toString("hex");
   }
 }
 


### PR DESCRIPTION
Using Math.random for security purposes is discouraged.
This PR uses the node.js crypto library to generate a new nonce instead.